### PR TITLE
Allow buffers to be passed in addition to file paths.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 npm-debug.log
+/.idea

--- a/index.js
+++ b/index.js
@@ -5,12 +5,18 @@ var parsers = require('./lib/parsers.js');
 
 module.exports = function (file) {
 	return new Promise(function (resolve, reject) {
-		fs.readFile(file, function (err, contents) {
-			if (err) return reject();
-			
-			Promise.any(parsers(contents)).then(function(result) {
-				resolve(result);
-			}, reject);
-		});
+		// If we're passed a buffer, parse it.
+		if(Buffer.isBuffer(file)) {
+			resolve(file);
+		} else {
+			// Otherwise read the file.
+			fs.readFile(file, function(err, contents) {
+				if(err) return reject();
+
+				resolve(contents);
+			});
+		}
+	}).then(function(contents) {
+		return Promise.any(parsers(contents));
 	});
 };

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,7 @@
 var path = require('path');
 var informer = require('../');
 var assert = require('assert');
+var fs = require('fs');
 
 describe('font-informer', function () {
 	it('can parse .ttf files', function (done) {
@@ -25,6 +26,37 @@ describe('font-informer', function () {
 		informer(path.join(__dirname, 'fonts/pathFont.svg')).then(function(result) {
 			assert.deepEqual(result, require('./expected.svg.json'));
 			done();
+		});
+	});
+
+	describe('parsing buffers', function() {
+		it('can parse .ttf buffers', function(done) {
+			var file = path.join(__dirname, 'fonts', 'pathFont.ttf');
+			informer(fs.readFileSync(file)).then(function(result) {
+				assert.deepEqual(result, require('./expected.ttf.json'));
+				done();
+			});
+		});
+		it('can parse .woff buffers', function(done) {
+			var file = path.join(__dirname, 'fonts', 'pathFont.woff');
+			informer(fs.readFileSync(file)).then(function(result) {
+				assert.deepEqual(result, require('./expected.woff.json'));
+				done();
+			});
+		});
+		it('can parse .eot buffers', function(done) {
+			var file = path.join(__dirname, 'fonts', 'pathFont.eot');
+			informer(fs.readFileSync(file)).then(function(result) {
+				assert.deepEqual(result, require('./expected.eot.json'));
+				done();
+			});
+		});
+		it('can parse .svg buffers', function(done) {
+			var file = path.join(__dirname, 'fonts', 'pathFont.svg');
+			informer(fs.readFileSync(file)).then(function(result) {
+				assert.deepEqual(result, require('./expected.svg.json'));
+				done();
+			});
 		});
 	});
 });


### PR DESCRIPTION
Figured I'd send this back to you.  This change allows any buffer to be passed and parsed instead of just file paths.  This is useful if you need to want to parse something that is not necessarily on the file system (for instance a url or file upload).
